### PR TITLE
Rimuove embed e lascia solo il link con xcancel

### DIFF
--- a/javascripts/discourse/initializers/discourse-twitter-native-embed.js
+++ b/javascripts/discourse/initializers/discourse-twitter-native-embed.js
@@ -33,7 +33,7 @@ export default {
                         xcancel_link.setAttribute("href", aa.href.replaceAll(/^https:\/\/.+\.com/gi, "https://xcancel.com"));
                         xcancel_link.text = aa.text.replaceAll(/^https:\/\/.+\.com/gi, "https://xcancel.com")
                         xcancel_link.setAttribute("rel", "no-follow");
-                        aa.appendChild(xcancel_link);
+//                        aa.appendChild(xcancel_link);
                     }
                 }
 //                for (const quote of el.getElementsByTagName("blockquote")) {

--- a/javascripts/discourse/initializers/discourse-twitter-native-embed.js
+++ b/javascripts/discourse/initializers/discourse-twitter-native-embed.js
@@ -7,7 +7,7 @@ export default {
     name: "discourse-twitter-native-embed-xcancel",
     initialize() {
         withPluginApi("1.0.0", api => {
-
+/*
             function getTwitterScript() {
                 var scriptnode = document.createElement('script');
                 scriptnode.setAttribute("async", "");
@@ -15,32 +15,34 @@ export default {
                 scriptnode.setAttribute("charset", "utf-8");
                 document.head.appendChild(scriptnode);
             }
+*/
             api.decorateCookedElement((el, helper) => {
-                let hasQuote = false;
+//                let hasQuote = false;
                 for (const the_musks_fxxking_url of ["twitter.com", "x.com"]) {
                     for (const aa of el.querySelectorAll(`a.onebox[href^="https://${the_musks_fxxking_url}/"][href*=status]`)) {
-                        const twitter_blockquoue = document.createElement("blockquote");
-                        twitter_blockquoue.setAttribute("style", "display: none");
-                        twitter_blockquoue.classList?.add("twitter-tweet");
-                        const aaa = document.createElement("a");
-                        aaa.setAttribute("href", aa.href.replaceAll("https://x.com", "https://twitter.com"));
-                        aaa.setAttribute("rel", "no-follow");
-                        twitter_blockquoue.appendChild(aaa);
-                        aa.appendChild(twitter_blockquoue);
-                        const xcancel_link = document.createElement("a");
+//                        const twitter_blockquoue = document.createElement("blockquote");
+//                        twitter_blockquoue.setAttribute("style", "display: none");
+//                        twitter_blockquoue.classList?.add("twitter-tweet");
+//                        const aaa = document.createElement("a");
+//                        aaa.setAttribute("href", aa.href.replaceAll("https://x.com", "https://twitter.com"));
+//                        aaa.setAttribute("rel", "no-follow");
+//                        twitter_blockquoue.appendChild(aaa);
+//                        aa.appendChild(twitter_blockquoue);
+//                        const xcancel_link = document.createElement("a");
+                        const xcancel_link = aa;
                         xcancel_link.setAttribute("href", aa.href.replaceAll(/^https:\/\/.+\.com/gi, "https://xcancel.com"));
-                        xcancel_link.text = "Apri in Xcancel";
+//                        xcancel_link.text = "Apri in Xcancel";
                         xcancel_link.setAttribute("rel", "no-follow");
                         aa.appendChild(xcancel_link);
                     }
                 }
-                for (const quote of el.getElementsByTagName("blockquote")) {
-                    if (quote.querySelector(`blockquote a[href^="https://twitter.com/"]`)) {
-                        quote.classList?.add("twitter-tweet");
-                        hasQuote = true;
-                    }
-                }
-                if (hasQuote) getTwitterScript();
+//                for (const quote of el.getElementsByTagName("blockquote")) {
+//                    if (quote.querySelector(`blockquote a[href^="https://twitter.com/"]`)) {
+//                        quote.classList?.add("twitter-tweet");
+//                        hasQuote = true;
+//                    }
+//               }
+//                if (hasQuote) getTwitterScript();
             }, {
                 id: "discourse-twitter-native-embed-xcancel",
                 afterAdopt: true,

--- a/javascripts/discourse/initializers/discourse-twitter-native-embed.js
+++ b/javascripts/discourse/initializers/discourse-twitter-native-embed.js
@@ -28,12 +28,11 @@ export default {
 //                        aaa.setAttribute("rel", "no-follow");
 //                        twitter_blockquoue.appendChild(aaa);
 //                        aa.appendChild(twitter_blockquoue);
-//                       const xcancel_link = document.createElement("a");
-                        const xcancel_link = aa;
+                        const xcancel_link = document.createElement("a");
                         xcancel_link.setAttribute("href", aa.href.replaceAll(/^https:\/\/.+\.com/gi, "https://xcancel.com"));
                         xcancel_link.text = aa.text.replaceAll(/^https:\/\/.+\.com/gi, "https://xcancel.com")
                         xcancel_link.setAttribute("rel", "no-follow");
-//                        aa.appendChild(xcancel_link);
+                        aa.appendChild(xcancel_link);
                     }
                 }
 //                for (const quote of el.getElementsByTagName("blockquote")) {

--- a/javascripts/discourse/initializers/discourse-twitter-native-embed.js
+++ b/javascripts/discourse/initializers/discourse-twitter-native-embed.js
@@ -33,7 +33,7 @@ export default {
                         xcancel_link.setAttribute("href", aa.href.replaceAll(/^https:\/\/.+\.com/gi, "https://xcancel.com"));
 //                        xcancel_link.text = "Apri in Xcancel";
                         xcancel_link.setAttribute("rel", "no-follow");
-                        aa.appendChild(xcancel_link);
+//                        aa.appendChild(xcancel_link);
                     }
                 }
 //                for (const quote of el.getElementsByTagName("blockquote")) {

--- a/javascripts/discourse/initializers/discourse-twitter-native-embed.js
+++ b/javascripts/discourse/initializers/discourse-twitter-native-embed.js
@@ -31,7 +31,7 @@ export default {
 //                        const xcancel_link = document.createElement("a");
                         const xcancel_link = aa;
                         xcancel_link.setAttribute("href", aa.href.replaceAll(/^https:\/\/.+\.com/gi, "https://xcancel.com"));
-//                        xcancel_link.text = "Apri in Xcancel";
+                        xcancel_link.text = aa.href.replaceAll(/^https:\/\/.+\.com/gi, "https://xcancel.com")
                         xcancel_link.setAttribute("rel", "no-follow");
 //                        aa.appendChild(xcancel_link);
                     }

--- a/javascripts/discourse/initializers/discourse-twitter-native-embed.js
+++ b/javascripts/discourse/initializers/discourse-twitter-native-embed.js
@@ -28,12 +28,12 @@ export default {
 //                        aaa.setAttribute("rel", "no-follow");
 //                        twitter_blockquoue.appendChild(aaa);
 //                        aa.appendChild(twitter_blockquoue);
-//                        const xcancel_link = document.createElement("a");
+//                       const xcancel_link = document.createElement("a");
                         const xcancel_link = aa;
                         xcancel_link.setAttribute("href", aa.href.replaceAll(/^https:\/\/.+\.com/gi, "https://xcancel.com"));
-                        xcancel_link.text = aa.href.replaceAll(/^https:\/\/.+\.com/gi, "https://xcancel.com")
+                        xcancel_link.text = aa.text.replaceAll(/^https:\/\/.+\.com/gi, "https://xcancel.com")
                         xcancel_link.setAttribute("rel", "no-follow");
-//                        aa.appendChild(xcancel_link);
+                        aa.appendChild(xcancel_link);
                     }
                 }
 //                for (const quote of el.getElementsByTagName("blockquote")) {

--- a/javascripts/discourse/initializers/discourse-twitter-native-embed.js
+++ b/javascripts/discourse/initializers/discourse-twitter-native-embed.js
@@ -28,11 +28,12 @@ export default {
 //                        aaa.setAttribute("rel", "no-follow");
 //                        twitter_blockquoue.appendChild(aaa);
 //                        aa.appendChild(twitter_blockquoue);
-                        const xcancel_link = document.createElement("a");
+//                        const xcancel_link = document.createElement("a");
+                        const xcancel_link = aa;
                         xcancel_link.setAttribute("href", aa.href.replaceAll(/^https:\/\/.+\.com/gi, "https://xcancel.com"));
                         xcancel_link.text = aa.text.replaceAll(/^https:\/\/.+\.com/gi, "https://xcancel.com")
                         xcancel_link.setAttribute("rel", "no-follow");
-                        aa.appendChild(xcancel_link);
+//                       aa.appendChild(xcancel_link);
                     }
                 }
 //                for (const quote of el.getElementsByTagName("blockquote")) {


### PR DESCRIPTION
Provato sul thread di staging, sembra funzionare bene ma c'è un link in particolare che non viene convertito e non so perché (v. thread).

Vediamo se in prod capitano altri casi o se c'è qualche meccanismo di cache in staging.